### PR TITLE
Fixes to make role work with new logstash 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,11 +2,13 @@
 
 logstash_enabled: yes                       # The role is enabled
 logstash_remove: no                         # Uninstall the role
-logstash_url: 'https://download.elastic.co/logstash/logstash/packages/debian/logstash_2.1.1-1_all.deb'
+logstash_version: '2.1'                     # this is used to determine the REPO path
+
 logstash_forwarder_url: https://download.elastic.co/logstash-forwarder/binaries/logstash-forwarder_0.4.0_amd64.deb
 
 logstash_apt_repositories:                  # These repositories will be added to system
 - ppa:webupd8team/java
+- "deb http://packages.elastic.co/logstash/{{ logstash_version }}/debian stable main"
 
 logstash_apt_common_pkgs:
 - acl
@@ -23,7 +25,7 @@ logstash_server_enabled: yes                # Setup logstash server
 logstash_forwarder_enabled: no              # Setup logstash forwarder
 logstash_web_enabled: no                    # Setup logstash web
 
-logstash_apt_key: http://packages.elasticsearch.org/GPG-KEY-elasticsearch
+logstash_apt_key: 'https://packages.elastic.co/GPG-KEY-elasticsearch'
 
 logstash_forwarder_home: /opt/logstash-forwarder
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 logstash_enabled: yes                       # The role is enabled
 logstash_remove: no                         # Uninstall the role
-logstash_url: https://download.elastic.co/logstash/logstash/packages/debian/logstash_1.4.2-1-2c0f5a1_all.deb
+logstash_url: 'https://download.elastic.co/logstash/logstash/packages/debian/logstash_2.1.1-1_all.deb'
 logstash_forwarder_url: https://download.elastic.co/logstash-forwarder/binaries/logstash-forwarder_0.4.0_amd64.deb
 
 logstash_apt_repositories:                  # These repositories will be added to system

--- a/tasks/configure-server.yml
+++ b/tasks/configure-server.yml
@@ -5,11 +5,13 @@
   when: not logstash_web_enabled
   changed_when: false
   tags: [logstash, logstash-configure]
+  ignore_erros: yes
 
 - name: logstash-configure | Enable logstash-web
   service: name=logstash-web state=started enabled=yes
   when: logstash_web_enabled
   tags: [logstash, logstash-configure]
+  ignore_erros: yes
 
 - name: logstash-configure | Setup configuration files
   template:
@@ -23,8 +25,8 @@
   tags: [logstash, logstash-configure]
 
 - name: logstash-configure | Setup patterns
-  template: src=pattern.j2 dest={{logstash_home}}/patterns/{{item[0]}} owner={{logstash_user}} group={{logstash_group}}
-  with_items: logstash_config_patterns.items()
+  template: src=pattern.j2 dest={{logstash_home}}/patterns/{{item.key}} owner={{logstash_user}} group={{logstash_group}}
+  with_dict: "{{ logstash_config_patterns }}"
   tags: [logstash, logstash-configure]
 
 - name: logstash-configure | Ensure the service is started

--- a/tasks/configure-server.yml
+++ b/tasks/configure-server.yml
@@ -5,13 +5,13 @@
   when: not logstash_web_enabled
   changed_when: false
   tags: [logstash, logstash-configure]
-  ignore_erros: yes
+  ignore_errors: yes
 
 - name: logstash-configure | Enable logstash-web
   service: name=logstash-web state=started enabled=yes
   when: logstash_web_enabled
   tags: [logstash, logstash-configure]
-  ignore_erros: yes
+  ignore_errors: yes
 
 - name: logstash-configure | Setup configuration files
   template:

--- a/tasks/configure-server.yml
+++ b/tasks/configure-server.yml
@@ -26,6 +26,14 @@
   with_items: [ 10-inputs.conf, 30-filters.conf, 50-outputs.conf ]
   tags: [logstash, logstash-configure]
 
+- name: logstash-configure | Ensure patterns directory
+  file:
+    name: "{{ logstash_home }}/patterns"
+    owner: "{{ logstash_user }}"
+    group: "{{ logstash_group }}"
+    state: "directory"
+    mode: "755"
+
 - name: logstash-configure | Setup patterns
   template: src=pattern.j2 dest={{logstash_home}}/patterns/{{item.key}} owner={{logstash_user}} group={{logstash_group}}
   with_dict: "{{ logstash_config_patterns }}"

--- a/tasks/configure-server.yml
+++ b/tasks/configure-server.yml
@@ -5,12 +5,14 @@
   when: not logstash_web_enabled
   changed_when: false
   tags: [logstash, logstash-configure]
+  # new versions of logstash no longer have logstash-web
   ignore_errors: yes
 
 - name: logstash-configure | Enable logstash-web
   service: name=logstash-web state=started enabled=yes
   when: logstash_web_enabled
   tags: [logstash, logstash-configure]
+  # new versions of logstash no longer have logstash-web
   ignore_errors: yes
 
 - name: logstash-configure | Setup configuration files

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -13,7 +13,7 @@
   with_items: logstash_apt_common_pkgs
 
 - name: logstash-install | Download logstash
-  get_url: url={{logstash_url}} dest={{logstash_home}}/logstash.deb
+  get_url: url={{logstash_url}} dest={{logstash_home}}/logstash.deb force=yes
   register: logstash_downloaded
 
 - name: logstash-install | Install logstash

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: logstash-install | Add logstash repo key
+  apt_key: url="{{ logstash_apt_key }}" state=present
+
 - name: logstash-install | Add repositories
   apt_repository: repo='{{item}}' update_cache=yes
   with_items: logstash_apt_repositories
@@ -12,13 +15,8 @@
   apt: pkg={{item}}
   with_items: logstash_apt_common_pkgs
 
-- name: logstash-install | Download logstash
-  get_url: url={{logstash_url}} dest={{logstash_home}}/logstash.deb force=yes
-  register: logstash_downloaded
-
 - name: logstash-install | Install logstash
-  apt: deb={{logstash_home}}/logstash.deb
-  when: logstash_downloaded.changed
+  apt: name="logstash" state="present" update_cache="yes"
 
 - name: logstash-install | Download logstash forwarder
   get_url: url={{logstash_forwarder_url}} dest={{logstash_home}}/logstash-forwarder.deb

--- a/templates/pattern.j2
+++ b/templates/pattern.j2
@@ -1,1 +1,1 @@
-{{ item[1] }}
+{{ item.value }}


### PR DESCRIPTION
Some small fixes to correct issues with running the role. Bigges issue was the iteration and ignoring errors for the calls for `logstash-web` which doesn't exist in versions after 1.4 (which is very old).

Pointed the default URL to newes 2.1.1 release of logstash.

Future enhancements might see replacing the logstash forward with the newer filebeats.
